### PR TITLE
Add strided permutation benchmark coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "rayon",
+ "smallvec",
  "strided-kernel",
  "strided-perm",
  "strided-traits",
@@ -1206,9 +1207,14 @@ name = "strided-rs-benchmark-suite"
 version = "0.1.0"
 dependencies = [
  "num-complex",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
  "strided-einsum2",
+ "strided-kernel",
  "strided-opteinsum",
  "strided-perm",
  "strided-view",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,13 @@ edition = "2021"
 [features]
 default = ["faer"]
 faer = ["strided-opteinsum/faer", "strided-einsum2/faer"]
-parallel = ["strided-opteinsum/parallel", "strided-einsum2/parallel"]
+parallel = [
+    "strided-opteinsum/parallel",
+    "strided-einsum2/parallel",
+    "strided-kernel/parallel",
+    "strided-perm/parallel",
+    "dep:rayon",
+]
 blas = ["strided-opteinsum/blas", "strided-einsum2/blas"]
 
 [profile.release-with-debug]
@@ -16,12 +22,25 @@ debug = true
 [dependencies]
 strided-opteinsum = { path = "../strided-rs/strided-opteinsum", default-features = false }
 strided-einsum2 = { path = "../strided-rs/strided-einsum2", default-features = false }
+strided-kernel = { path = "../strided-rs/strided-kernel", default-features = false }
 strided-view = { path = "../strided-rs/strided-view" }
 strided-perm = { path = "../strided-rs/strided-perm" }
 num-complex = "0.4"
+num-traits = "0.2"
+rand = "0.9"
+rand_distr = "0.5"
+rayon = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [[bin]]
 name = "step408_bench"
 path = "micro_bench/step408_bench.rs"
+
+[[bin]]
+name = "scale_transpose"
+path = "micro_bench/scale_transpose.rs"
+
+[[bin]]
+name = "permute"
+path = "micro_bench/permute.rs"

--- a/micro_bench/README.md
+++ b/micro_bench/README.md
@@ -18,30 +18,318 @@ julia --project=. micro_bench/step408_bench.jl
 julia --project=. micro_bench/step408_fair.jl
 ```
 
-## Results (AMD EPYC 7713P)
+## Results (Apple M5 MacBook Pro)
+
+Measured on macOS, 2026-07-02. macOS runs are not CPU-pinned.
+
+- Rust compiler flags: `RUSTFLAGS="-C target-cpu=native"`
+- strided-rs: `91a0aca`
+- benchmark suite: this commit
+- Julia environment: Manifest-instantiated `OMEinsum v0.9.3`
+
+### Rust BLAS
+
+Median milliseconds. Run with
+`cargo run --release --no-default-features --features blas --bin step408_bench`.
+
+| Threads | full scattered | copy B | copy A | contiguous GEMM |
+|---:|---:|---:|---:|---:|
+| 1 | 16.805 | 12.302 | 0.006 | 5.193 |
+| 4 | 16.759 | 12.504 | 0.005 | 5.183 |
+
+### Julia Decomposition
+
+Median milliseconds. Run with `julia --project=. micro_bench/step408_bench.jl`.
+The manual `permutedims! + BLAS gemm` path in this script currently reports a
+large max error, so treat this table as component timing, not correctness
+validation.
+
+| Threads | OMEinsum DynamicEinCode | permutedims! + BLAS | permutedims! B | permutedims! A | BLAS GEMM |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 5.926 | 27.941 | 22.110 | 0.008 | 5.770 |
+| 4 | 2.197 | 24.692 | 22.370 | 0.008 | 2.043 |
+
+### Julia Fair Comparison
+
+Median milliseconds. Run with `julia --project=. micro_bench/step408_fair.jl`.
+
+| Threads | OMEinsum scrambled | OMEinsum natural | permutedims! B Rust perm | permutedims! B batch-front | BLAS GEMM |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 27.695 | 5.848 | 21.773 | 16.779 | 5.765 |
+| 4 | 24.549 | 2.132 | 21.832 | 16.909 | 2.072 |
+
+# Permutation Micro-benchmark
+
+Migrated from `strided-perm/benches/permute.rs`. Covers the high-rank binary
+permutation, contiguous-source permutation, memcpy baseline, small tensors, and
+large 3D transposes.
+
+## Run
+
+Run these sequentially. Do not run thread-count variants at the same time.
+
+```bash
+RUSTFLAGS="-C target-cpu=native" \
+  RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+  cargo run --release --bin permute
+
+RUSTFLAGS="-C target-cpu=native" \
+  RAYON_NUM_THREADS=4 OMP_NUM_THREADS=1 \
+  cargo run --release --features parallel --bin permute
+```
+
+## Results (Apple M5 MacBook Pro)
+
+Measured on macOS, 2026-07-02. macOS runs are not CPU-pinned.
+
+- compiler flags: `RUSTFLAGS="-C target-cpu=native"`
+- strided-rs: `91a0aca`
+- benchmark suite: this commit
+
+Median milliseconds.
 
 ### 1T
 
-| Operation | Rust (blas) | Julia |
-|---|---|---|
-| Full einsum (scrambled labels) | 300 ms | 108 ms |
-| Full einsum (natural labels) | — | 19 ms |
-| copy_into/permutedims B (scattered perm) | 236 ms | 58 ms |
-| GEMM only | 63 ms | 18 ms |
+| Scenario | Path | ms |
+|---|---|---:|
+| memcpy baseline | `std::ptr::copy_nonoverlapping` | 1.911 |
+| memcpy baseline | `copy_into` contiguous fast path | 1.913 |
+| 24D scattered -> col-major | naive odometer | 20.212 |
+| 24D scattered -> col-major | `copy_into` | 5.124 |
+| 24D scattered -> col-major | `copy_into_col_major` | 5.153 |
+| 24D contig source, same perm | `copy_into` | 3.186 |
+| 24D contig -> contig perm | `copy_into` | 3.165 |
+| 24D contig -> contig perm | `copy_into_col_major` | 3.206 |
+| 24D contig -> contig perm | naive odometer | 18.167 |
+| 13D small reverse | `copy_into` | 0.004 |
+| 13D small cyclic | `copy_into` | 0.003 |
+| 13D small reverse | naive odometer | 0.009 |
+| 3D 256^3 [2,0,1] | `copy_into` | 14.416 |
+| 3D 256^3 [2,0,1] | `copy_into_col_major` | 14.454 |
+| 3D 256^3 [2,0,1] | naive odometer | 61.731 |
+| 3D 256^3 [1,0,2] | `copy_into` | 11.078 |
 
 ### 4T
 
-| Operation | Rust (blas) | Julia |
-|---|---|---|
-| Full einsum (scrambled labels) | 313 ms | 102 ms |
-| Full einsum (natural labels) | — | 5 ms |
-| copy_into/permutedims B (scattered perm) | 241 ms | 63 ms |
-| GEMM only | 62 ms | 5 ms |
+| Scenario | Path | ms |
+|---|---|---:|
+| memcpy baseline | `std::ptr::copy_nonoverlapping` | 1.916 |
+| memcpy baseline | `copy_into` contiguous fast path | 1.916 |
+| 24D scattered -> col-major | naive odometer | 20.140 |
+| 24D scattered -> col-major | `copy_into` | 5.116 |
+| 24D scattered -> col-major | `copy_into_col_major` | 5.157 |
+| 24D scattered -> col-major | `copy_into_par` | 3.048 |
+| 24D scattered -> col-major | `copy_into_col_major_par` | 3.253 |
+| 24D contig source, same perm | `copy_into` | 3.280 |
+| 24D contig -> contig perm | `copy_into` | 3.214 |
+| 24D contig -> contig perm | `copy_into_col_major` | 3.222 |
+| 24D contig -> contig perm | naive odometer | 18.945 |
+| 24D contig -> contig perm | `copy_into_par` | 1.152 |
+| 13D small reverse | `copy_into` | 0.004 |
+| 13D small cyclic | `copy_into` | 0.002 |
+| 13D small reverse | naive odometer | 0.009 |
+| 13D small reverse | `copy_into_par` | 0.004 |
+| 3D 256^3 [2,0,1] | `copy_into` | 13.315 |
+| 3D 256^3 [2,0,1] | `copy_into_col_major` | 13.294 |
+| 3D 256^3 [2,0,1] | naive odometer | 45.754 |
+| 3D 256^3 [2,0,1] | `copy_into_par` | 4.792 |
+| 3D 256^3 [1,0,2] | `copy_into` | 11.056 |
+| 3D 256^3 [1,0,2] | `copy_into_par` | 3.244 |
 
-## Root Causes
+# Scale Transpose Micro-benchmark
 
-1. **`strided_perm::copy_into` is 4x slower than Julia's `permutedims!`** for 24-dim binary tensors with scattered permutation. Julia's `permutedims!` uses a simpler recursive approach that is more cache-friendly for high-rank small-dim tensors.
+Tracks 2D transpose-scale paths where a raw pointer naive loop previously
+matched or beat the strided implementation.
 
-2. **Batched GEMM overhead**: Rust's einsum2 dispatches 8 separate GEMM calls with m=4, k=256, n=8192. The per-call overhead (plan building, validation, prepare_input_owned checks) adds up. Julia's `mul!` goes directly to BLAS with minimal overhead.
+Cases:
 
-3. **Label ordering**: In the full benchmark, OMEinsum.jl stores intermediates contiguously with sorted labels, so subsequent steps need minimal permutation. strided-rs uses lazy permutation, causing accumulated scrambled strides that require expensive copy-to-contiguous.
+- dtypes: `f32`, `f64`, `c32`, `c64`, `u64`
+- sizes: `1000`, `1024`, `2048` by default
+- scales: `0`, `1`, `3`
+- paths: raw pointer naive, `copy_transpose_scale_into`, `map_into` on a
+  transposed view, and `strided_perm::copy_into` for `scale == 1`
+
+## Run
+
+Run these sequentially. Do not run thread-count variants at the same time.
+
+```bash
+# Exploratory local run
+RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+  cargo run --release --bin scale_transpose
+
+RAYON_NUM_THREADS=4 OMP_NUM_THREADS=1 \
+  cargo run --release --features parallel --bin scale_transpose
+
+# Faster smoke run
+SIZES=1000 WARMUP=1 NRUNS=3 \
+  RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+  cargo run --release --bin scale_transpose
+```
+
+For README result updates on Linux, pin cores as required by `AGENTS.md`, for
+example `taskset -c 0` for 1T and `taskset -c 0-3` for 4T.
+
+## Results (Apple M5 MacBook Pro)
+
+Measured on macOS, 2026-07-02. macOS runs are not CPU-pinned.
+
+- benchmark command: `SIZES=1000,1024,2048 WARMUP=3 NRUNS=11`
+- compiler flags: `RUSTFLAGS="-C target-cpu=native"`
+- strided-rs: `91a0aca`
+- benchmark suite: this commit
+
+### 1T
+
+Median milliseconds. `copy_into` is reported only for `scale=1`.
+
+| dtype | n | scale | naive | strided | map | copy_into |
+|---|---:|---:|---:|---:|---:|---:|
+| f32 | 1000 | 0 | 0.015 | 0.015 | 0.354 | - |
+| f32 | 1000 | 1 | 0.185 | 0.142 | 0.357 | 0.188 |
+| f32 | 1000 | 3 | 0.185 | 0.146 | 0.376 | - |
+| f32 | 1024 | 0 | 0.016 | 0.016 | 0.751 | - |
+| f32 | 1024 | 1 | 1.116 | 0.361 | 0.757 | 0.262 |
+| f32 | 1024 | 3 | 1.106 | 0.346 | 0.752 | - |
+| f32 | 2048 | 0 | 0.064 | 0.064 | 3.609 | - |
+| f32 | 2048 | 1 | 9.124 | 2.266 | 3.549 | 2.595 |
+| f32 | 2048 | 3 | 9.019 | 2.303 | 3.481 | - |
+| f64 | 1000 | 0 | 0.030 | 0.030 | 0.488 | - |
+| f64 | 1000 | 1 | 0.237 | 0.189 | 0.487 | 0.268 |
+| f64 | 1000 | 3 | 0.238 | 0.197 | 0.486 | - |
+| f64 | 1024 | 0 | 0.032 | 0.032 | 0.998 | - |
+| f64 | 1024 | 1 | 1.214 | 0.432 | 0.910 | 0.563 |
+| f64 | 1024 | 3 | 1.273 | 0.434 | 0.930 | - |
+| f64 | 2048 | 0 | 0.127 | 0.129 | 6.329 | - |
+| f64 | 2048 | 1 | 11.709 | 3.367 | 6.271 | 5.031 |
+| f64 | 2048 | 3 | 11.754 | 3.610 | 6.370 | - |
+| c32 | 1000 | 0 | 0.030 | 0.030 | 0.583 | - |
+| c32 | 1000 | 1 | 0.380 | 0.280 | 0.538 | 0.302 |
+| c32 | 1000 | 3 | 0.377 | 0.299 | 0.542 | - |
+| c32 | 1024 | 0 | 0.031 | 0.032 | 1.048 | - |
+| c32 | 1024 | 1 | 1.171 | 0.454 | 0.937 | 0.541 |
+| c32 | 1024 | 3 | 1.226 | 0.456 | 0.940 | - |
+| c32 | 2048 | 0 | 0.129 | 0.128 | 6.426 | - |
+| c32 | 2048 | 1 | 11.633 | 4.064 | 6.446 | 4.994 |
+| c32 | 2048 | 3 | 11.625 | 3.881 | 6.468 | - |
+| c64 | 1000 | 0 | 0.061 | 0.061 | 1.401 | - |
+| c64 | 1000 | 1 | 0.566 | 0.544 | 1.279 | 0.624 |
+| c64 | 1000 | 3 | 0.569 | 0.556 | 1.288 | - |
+| c64 | 1024 | 0 | 0.063 | 0.063 | 1.760 | - |
+| c64 | 1024 | 1 | 2.015 | 0.904 | 1.731 | 3.699 |
+| c64 | 1024 | 3 | 1.912 | 0.919 | 1.693 | - |
+| c64 | 2048 | 0 | 0.256 | 0.256 | 8.999 | - |
+| c64 | 2048 | 1 | 13.671 | 6.846 | 8.947 | 14.839 |
+| c64 | 2048 | 3 | 14.519 | 6.885 | 8.940 | - |
+| u64 | 1000 | 0 | 0.031 | 0.031 | 0.505 | - |
+| u64 | 1000 | 1 | 0.239 | 0.197 | 0.505 | 0.275 |
+| u64 | 1000 | 3 | 0.235 | 0.197 | 0.490 | - |
+| u64 | 1024 | 0 | 0.032 | 0.032 | 0.993 | - |
+| u64 | 1024 | 1 | 1.324 | 0.442 | 0.901 | 0.540 |
+| u64 | 1024 | 3 | 1.284 | 0.449 | 0.899 | - |
+| u64 | 2048 | 0 | 0.125 | 0.126 | 6.151 | - |
+| u64 | 2048 | 1 | 11.841 | 3.500 | 6.096 | 5.008 |
+| u64 | 2048 | 3 | 11.910 | 3.512 | 6.152 | - |
+
+### 4T
+
+Median milliseconds. `copy_into` is reported only for `scale=1`.
+
+| dtype | n | scale | naive | strided | map | copy_into |
+|---|---:|---:|---:|---:|---:|---:|
+| f32 | 1000 | 0 | 0.023 | 0.019 | 0.205 | - |
+| f32 | 1000 | 1 | 0.254 | 0.093 | 0.304 | 0.232 |
+| f32 | 1000 | 3 | 0.232 | 0.085 | 0.281 | - |
+| f32 | 1024 | 0 | 0.018 | 0.018 | 0.413 | - |
+| f32 | 1024 | 1 | 1.175 | 0.133 | 0.383 | 0.248 |
+| f32 | 1024 | 3 | 1.095 | 0.122 | 0.340 | - |
+| f32 | 2048 | 0 | 0.065 | 0.064 | 1.656 | - |
+| f32 | 2048 | 1 | 6.786 | 1.366 | 1.605 | 2.608 |
+| f32 | 2048 | 3 | 6.964 | 1.174 | 1.448 | - |
+| f64 | 1000 | 0 | 0.033 | 0.030 | 0.158 | - |
+| f64 | 1000 | 1 | 0.240 | 0.091 | 0.155 | 0.274 |
+| f64 | 1000 | 3 | 0.245 | 0.087 | 0.158 | - |
+| f64 | 1024 | 0 | 0.031 | 0.031 | 0.280 | - |
+| f64 | 1024 | 1 | 1.180 | 0.218 | 0.319 | 0.605 |
+| f64 | 1024 | 3 | 1.187 | 0.179 | 0.278 | - |
+| f64 | 2048 | 0 | 0.123 | 0.126 | 2.043 | - |
+| f64 | 2048 | 1 | 11.260 | 1.809 | 1.983 | 4.988 |
+| f64 | 2048 | 3 | 11.560 | 1.728 | 2.044 | - |
+| c32 | 1000 | 0 | 0.031 | 0.034 | 0.221 | - |
+| c32 | 1000 | 1 | 0.399 | 0.128 | 0.201 | 0.312 |
+| c32 | 1000 | 3 | 0.395 | 0.114 | 0.179 | - |
+| c32 | 1024 | 0 | 0.032 | 0.033 | 0.326 | - |
+| c32 | 1024 | 1 | 1.210 | 0.232 | 0.346 | 0.524 |
+| c32 | 1024 | 3 | 1.154 | 0.203 | 0.294 | - |
+| c32 | 2048 | 0 | 0.127 | 0.126 | 2.045 | - |
+| c32 | 2048 | 1 | 11.488 | 1.814 | 2.019 | 4.996 |
+| c32 | 2048 | 3 | 10.816 | 1.788 | 1.937 | - |
+| c64 | 1000 | 0 | 0.061 | 0.061 | 0.631 | - |
+| c64 | 1000 | 1 | 0.547 | 0.181 | 0.583 | 0.494 |
+| c64 | 1000 | 3 | 0.550 | 0.184 | 0.647 | - |
+| c64 | 1024 | 0 | 0.064 | 0.065 | 0.802 | - |
+| c64 | 1024 | 1 | 1.775 | 0.371 | 0.807 | 3.662 |
+| c64 | 1024 | 3 | 1.769 | 0.354 | 0.792 | - |
+| c64 | 2048 | 0 | 0.258 | 0.257 | 2.678 | - |
+| c64 | 2048 | 1 | 14.510 | 2.241 | 2.598 | 14.580 |
+| c64 | 2048 | 3 | 13.556 | 2.304 | 2.650 | - |
+| u64 | 1000 | 0 | 0.030 | 0.031 | 0.177 | - |
+| u64 | 1000 | 1 | 0.237 | 0.095 | 0.170 | 0.284 |
+| u64 | 1000 | 3 | 0.237 | 0.094 | 0.173 | - |
+| u64 | 1024 | 0 | 0.031 | 0.032 | 0.296 | - |
+| u64 | 1024 | 1 | 1.191 | 0.184 | 0.293 | 0.640 |
+| u64 | 1024 | 3 | 1.194 | 0.178 | 0.278 | - |
+| u64 | 2048 | 0 | 0.121 | 0.123 | 1.922 | - |
+| u64 | 2048 | 1 | 10.893 | 1.800 | 1.955 | 5.141 |
+| u64 | 2048 | 3 | 12.024 | 1.764 | 1.897 | - |
+
+# HPTT Comparison Micro-benchmark
+
+Compares HPTT C++ against directly matching contiguous-source tensor transpose
+cases. HPTT supports contiguous source tensor transpositions with an optional
+output update; cases that require arbitrary source strides or only have
+timing-only validation are intentionally omitted.
+
+## Run
+
+Requires an OpenMP-capable C++ compiler. On macOS, install Homebrew GCC and run
+with `g++-15`:
+
+```bash
+HPTT_DIR=../hptt CXX=/opt/homebrew/bin/g++-15 \
+  THREADS=1 WARMUP=3 NRUNS=11 \
+  micro_bench/run_hptt_compare.sh
+
+HPTT_DIR=../hptt CXX=/opt/homebrew/bin/g++-15 \
+  THREADS=4 WARMUP=3 NRUNS=11 \
+  micro_bench/run_hptt_compare.sh
+```
+
+The benchmark reports both reusable-plan execution time (`hptt execute`) and
+plan construction plus execution (`hptt create+execute`). The runner performs
+sample correctness checks for every reported case.
+
+## Results (Apple M5 MacBook Pro)
+
+Measured on macOS, 2026-07-02. macOS runs are not CPU-pinned.
+
+- compiler: Homebrew GCC `g++-15` with `-O3 -DNDEBUG -fopenmp -mcpu=native`
+- HPTT source: local clone at `../hptt`
+
+Median milliseconds.
+
+### 1T
+
+| Scenario | HPTT execute | HPTT create+execute |
+|---|---:|---:|
+| 2D 1024^2 transpose [1,0] | 0.655 | 0.648 |
+| 3D 256^3 transpose [2,0,1] | 24.473 | 24.477 |
+| 3D 256^3 transpose [1,0,2] | 14.329 | 14.310 |
+
+### 4T
+
+| Scenario | HPTT execute | HPTT create+execute |
+|---|---:|---:|
+| 2D 1024^2 transpose [1,0] | 0.201 | 0.224 |
+| 3D 256^3 transpose [2,0,1] | 7.929 | 7.956 |
+| 3D 256^3 transpose [1,0,2] | 4.384 | 4.614 |

--- a/micro_bench/hptt_compare.cpp
+++ b/micro_bench/hptt_compare.cpp
@@ -1,0 +1,225 @@
+#include <hptt.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+int env_int(const char* name, int fallback) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+  return std::stoi(value);
+}
+
+std::size_t product(const std::vector<int>& dims) {
+  std::size_t total = 1;
+  for (int dim : dims) {
+    total *= static_cast<std::size_t>(dim);
+  }
+  return total;
+}
+
+std::vector<std::size_t> col_major_strides(const std::vector<int>& dims) {
+  std::vector<std::size_t> strides(dims.size(), 1);
+  for (std::size_t i = 1; i < dims.size(); ++i) {
+    strides[i] = strides[i - 1] * static_cast<std::size_t>(dims[i - 1]);
+  }
+  return strides;
+}
+
+std::vector<int> permuted_dims(const std::vector<int>& dims, const std::vector<int>& perm) {
+  std::vector<int> out(dims.size());
+  for (std::size_t i = 0; i < dims.size(); ++i) {
+    out[i] = dims[static_cast<std::size_t>(perm[i])];
+  }
+  return out;
+}
+
+std::size_t permuted_destination_offset(
+    std::size_t src_flat,
+    const std::vector<int>& dims,
+    const std::vector<int>& perm) {
+  const auto src_strides = col_major_strides(dims);
+  const auto out_dims = permuted_dims(dims, perm);
+  const auto dst_strides = col_major_strides(out_dims);
+  std::vector<int> src_idx(dims.size(), 0);
+  std::vector<int> dst_idx(dims.size(), 0);
+
+  for (std::size_t d = dims.size(); d-- > 0;) {
+    src_idx[d] = static_cast<int>(src_flat / src_strides[d]);
+    src_flat %= src_strides[d];
+  }
+  for (std::size_t d = 0; d < dims.size(); ++d) {
+    dst_idx[d] = src_idx[static_cast<std::size_t>(perm[d])];
+  }
+
+  std::size_t dst_flat = 0;
+  for (std::size_t d = 0; d < dims.size(); ++d) {
+    dst_flat += static_cast<std::size_t>(dst_idx[d]) * dst_strides[d];
+  }
+  return dst_flat;
+}
+
+std::vector<double> make_input(std::size_t total) {
+  std::vector<double> data(total);
+  for (std::size_t i = 0; i < total; ++i) {
+    data[i] = static_cast<double>((i * 1315423911ULL) & 0xffff) * 0.25 + 1.0;
+  }
+  return data;
+}
+
+double median_ms(std::vector<double>& samples) {
+  std::sort(samples.begin(), samples.end());
+  return samples[samples.size() / 2];
+}
+
+double iqr_ms(const std::vector<double>& sorted_samples) {
+  return sorted_samples[3 * sorted_samples.size() / 4] - sorted_samples[sorted_samples.size() / 4];
+}
+
+void bench(const std::string& label, std::size_t bytes, int warmup, int nruns, const std::function<void()>& f) {
+  for (int i = 0; i < warmup; ++i) {
+    f();
+  }
+
+  std::vector<double> samples;
+  samples.reserve(static_cast<std::size_t>(nruns));
+  for (int i = 0; i < nruns; ++i) {
+    auto t0 = Clock::now();
+    f();
+    auto t1 = Clock::now();
+    samples.push_back(std::chrono::duration<double, std::milli>(t1 - t0).count());
+  }
+
+  std::sort(samples.begin(), samples.end());
+  const double med = median_ms(samples);
+  const double iqr = iqr_ms(samples);
+  const double gbps = static_cast<double>(bytes) / (med / 1000.0) / 1.0e9;
+  std::cout << "  " << label;
+  for (std::size_t i = label.size(); i < 28; ++i) {
+    std::cout << ' ';
+  }
+  std::cout << med << " ms (IQR " << iqr << ")  " << gbps << " GB/s\n";
+}
+
+void verify_case(
+    const std::string& name,
+    const std::vector<double>& src,
+    const std::vector<double>& dst,
+    const std::vector<int>& dims,
+    const std::vector<int>& perm) {
+  const std::size_t total = product(dims);
+  const std::vector<std::size_t> samples = {
+      0,
+      total > 1 ? std::size_t{1} : std::size_t{0},
+      total / 3,
+      total / 2,
+      total > 0 ? total - 1 : 0,
+  };
+  for (std::size_t src_flat : samples) {
+    const std::size_t dst_flat = permuted_destination_offset(src_flat, dims, perm);
+    if (dst[dst_flat] != src[src_flat]) {
+      throw std::runtime_error("verification failed for " + name);
+    }
+  }
+}
+
+void run_case(
+    const std::string& name,
+    const std::vector<int>& dims,
+    const std::vector<int>& perm,
+    int threads,
+    int warmup,
+    int nruns) {
+  const std::size_t total = product(dims);
+  const std::size_t bytes = total * sizeof(double) * 2;
+  auto src = make_input(total);
+  std::vector<double> dst(total, 0.0);
+
+  auto plan = hptt::create_plan(
+      perm.data(),
+      static_cast<int>(dims.size()),
+      1.0,
+      src.data(),
+      dims.data(),
+      nullptr,
+      0.0,
+      dst.data(),
+      nullptr,
+      hptt::ESTIMATE,
+      threads);
+
+  plan->execute();
+  if (dims.size() <= 8) {
+    verify_case(name, src, dst, dims, perm);
+  }
+
+  std::cout << "=== " << name << " ===\n";
+  bench("hptt execute", bytes, warmup, nruns, [&]() {
+    plan->execute();
+  });
+
+  bench("hptt create+execute", bytes, warmup, nruns, [&]() {
+    auto local_plan = hptt::create_plan(
+        perm.data(),
+        static_cast<int>(dims.size()),
+        1.0,
+        src.data(),
+        dims.data(),
+        nullptr,
+        0.0,
+        dst.data(),
+        nullptr,
+        hptt::ESTIMATE,
+        threads);
+    local_plan->execute();
+  });
+  std::cout << '\n';
+}
+
+}  // namespace
+
+int main() {
+  const int threads = env_int("THREADS", 1);
+  const int warmup = env_int("WARMUP", 3);
+  const int nruns = env_int("NRUNS", 11);
+
+  std::cout << "HPTT comparison benchmark\n";
+  std::cout << "threads=" << threads << " warmup=" << warmup << " nruns=" << nruns << "\n";
+  std::cout << "columns: label median_ms(iqr) bandwidth_GB/s\n\n";
+
+  run_case(
+      "2D 1024^2 transpose [1,0]",
+      {1024, 1024},
+      {1, 0},
+      threads,
+      warmup,
+      nruns);
+
+  run_case(
+      "3D 256^3 transpose [2,0,1]",
+      {256, 256, 256},
+      {2, 0, 1},
+      threads,
+      warmup,
+      nruns);
+
+  run_case(
+      "3D 256^3 transpose [1,0,2]",
+      {256, 256, 256},
+      {1, 0, 2},
+      threads,
+      warmup,
+      nruns);
+}

--- a/micro_bench/permute.rs
+++ b/micro_bench/permute.rs
@@ -1,0 +1,503 @@
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand_distr::StandardNormal;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+#[allow(unused_imports)]
+#[cfg(feature = "parallel")]
+use strided_perm::copy_into_col_major_par;
+#[cfg(feature = "parallel")]
+use strided_perm::copy_into_par;
+use strided_perm::{copy_into, copy_into_col_major};
+use strided_view::{col_major_strides, StridedArray};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn median(samples: &mut [Duration]) -> Duration {
+    samples.sort();
+    let n = samples.len();
+    if n % 2 == 1 {
+        samples[n / 2]
+    } else {
+        (samples[n / 2 - 1] + samples[n / 2]) / 2
+    }
+}
+
+fn bench_n(label: &str, warmup: usize, iters: usize, bytes: usize, mut f: impl FnMut()) {
+    for _ in 0..warmup {
+        f();
+    }
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        f();
+        samples.push(t0.elapsed());
+    }
+    let med = median(&mut samples);
+    let ms = med.as_secs_f64() * 1e3;
+    let gbps = (bytes as f64) / med.as_secs_f64() / 1e9;
+    // p25 and p75
+    let p25 = samples[samples.len() / 4].as_secs_f64() * 1e3;
+    let p75 = samples[samples.len() * 3 / 4].as_secs_f64() * 1e3;
+    println!("  {label:30} {ms:8.3} ms  ({p25:.3} / {p75:.3})  {gbps:6.2} GB/s");
+}
+
+fn make_random_array(dims: &[usize], strides: &[isize], seed: u64) -> StridedArray<f64> {
+    let total: usize = dims.iter().product();
+    let mut rng = StdRng::seed_from_u64(seed);
+    let data: Vec<f64> = (0..total).map(|_| rng.sample(StandardNormal)).collect();
+    StridedArray::from_parts(data, dims, strides, 0).unwrap()
+}
+
+/// Generic strided copy using odometer iteration.
+///
+/// Iterates over `dims` in col-major order, reading from `src_ptr` using
+/// `src_strides` and writing to `dst_ptr` using `dst_strides`.
+unsafe fn naive_strided_copy(
+    src_ptr: *const f64,
+    dst_ptr: *mut f64,
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+) {
+    let rank = dims.len();
+    let total: usize = dims.iter().product();
+
+    let mut idx = vec![0usize; rank];
+    let mut src_off = 0isize;
+    let mut dst_off = 0isize;
+
+    for _ in 0..total {
+        *dst_ptr.offset(dst_off) = *src_ptr.offset(src_off);
+        for d in 0..rank {
+            idx[d] += 1;
+            src_off += src_strides[d];
+            dst_off += dst_strides[d];
+            if idx[d] < dims[d] {
+                break;
+            }
+            src_off -= (idx[d] as isize) * src_strides[d];
+            dst_off -= (idx[d] as isize) * dst_strides[d];
+            idx[d] = 0;
+        }
+    }
+}
+
+/// Convenience: naive permuted copy from col-major source.
+///
+/// B[i_0, ..., i_{N-1}] = A[i_{perm[0]}, ..., i_{perm[N-1]}]
+unsafe fn naive_permute_colmajor(
+    a_ptr: *const f64,
+    b_ptr: *mut f64,
+    dims: &[usize],
+    perm: &[usize],
+) {
+    let rank = dims.len();
+    let cm = col_major_strides(dims);
+    let src_perm: Vec<isize> = (0..rank).map(|d| cm[perm[d]]).collect();
+    naive_strided_copy(a_ptr, b_ptr, dims, &src_perm, &cm);
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+/// Scenario 1: Scattered stride → col-major (the critical bottleneck)
+///
+/// 24 dimensions, all size 2, 16,777,216 elements (128 MB as f64).
+/// Source strides from tensornetwork_permutation_light_415 Step 408.
+fn scenario_scattered_to_colmajor() {
+    println!("=== Scenario 1: Scattered stride → col-major (24 dims, 16M elems) ===");
+
+    let rank = 24;
+    let dims = vec![2usize; rank];
+    let total: usize = 1 << rank; // 2^24 = 16,777,216
+    let bytes = total * std::mem::size_of::<f64>() * 2; // read + write
+
+    // Scattered source strides from the real workload
+    let src_strides: Vec<isize> = vec![
+        1, 2, 4, 8, 4194304, 16, 8388608, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+        32768, 65536, 131072, 262144, 524288, 1048576, 2097152,
+    ];
+
+    // The inverse permutation: maps src stride order to col-major order
+    let perm_inv: Vec<usize> = vec![
+        0, 1, 2, 3, 22, 4, 23, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    ];
+
+    let src = make_random_array(&dims, &src_strides, 42);
+    let mut dst = StridedArray::<f64>::col_major(&dims);
+    let dst_strides = col_major_strides(&dims);
+
+    // Build the permuted view: permute src so that dst is col-major
+    let src_view = src.view();
+    let src_perm = src_view.permute(&perm_inv).unwrap();
+
+    // Naive baseline (using actual permuted strides)
+    {
+        let a_ptr = src.data().as_ptr();
+        let b_ptr = dst.data_mut().as_mut_ptr();
+        let perm_strides: Vec<isize> = src_perm.strides().to_vec();
+        let dst_cm = col_major_strides(&dims);
+        bench_n("naive_odometer", 2, 30, bytes, || {
+            unsafe { naive_strided_copy(a_ptr, b_ptr, &dims, &perm_strides, &dst_cm) };
+            black_box(b_ptr);
+        });
+    }
+
+    // strided-perm copy_into
+    bench_n("strided_perm::copy_into", 2, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // strided-perm copy_into_col_major
+    bench_n("strided_perm::copy_into_col_major", 2, 30, bytes, || {
+        copy_into_col_major(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Also bench with contiguous source permuted view (what copy_into sees)
+    // to separate "scattered stride" effect from "permutation" effect
+    let src_contig = make_random_array(&dims, &dst_strides, 42);
+    let src_contig_perm = src_contig.view().permute(&perm_inv).unwrap();
+    bench_n("copy_into (contig src, same perm)", 2, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_contig_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Parallel variants
+    #[cfg(feature = "parallel")]
+    {
+        bench_n("copy_into_par", 2, 30, bytes, || {
+            copy_into_par(&mut dst.view_mut(), &src_perm).unwrap();
+            black_box(dst.data().as_ptr());
+        });
+        bench_n("copy_into_col_major_par", 2, 30, bytes, || {
+            copy_into_col_major_par(&mut dst.view_mut(), &src_perm).unwrap();
+            black_box(dst.data().as_ptr());
+        });
+    }
+
+    println!();
+}
+
+/// Scenario 2: Contiguous → contiguous permutation
+///
+/// Same shape as Scenario 1 but source is col-major.
+/// Measures "always materialize" strategy cost.
+fn scenario_contig_to_contig_perm() {
+    println!("=== Scenario 2: Contiguous → contiguous permutation (24 dims, 16M elems) ===");
+
+    let rank = 24;
+    let dims = vec![2usize; rank];
+    let total: usize = 1 << rank;
+    let bytes = total * std::mem::size_of::<f64>() * 2;
+    let strides = col_major_strides(&dims);
+
+    let perm_inv: Vec<usize> = vec![
+        0, 1, 2, 3, 22, 4, 23, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    ];
+
+    let src = make_random_array(&dims, &strides, 123);
+    let mut dst = StridedArray::<f64>::col_major(&dims);
+
+    let src_perm = src.view().permute(&perm_inv).unwrap();
+
+    bench_n("strided_perm::copy_into", 2, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    bench_n("strided_perm::copy_into_col_major", 2, 30, bytes, || {
+        copy_into_col_major(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Naive baseline
+    {
+        let a_ptr = src.data().as_ptr();
+        let b_ptr = dst.data_mut().as_mut_ptr();
+        bench_n("naive_odometer", 2, 30, bytes, || {
+            unsafe { naive_permute_colmajor(a_ptr, b_ptr, &dims, &perm_inv) };
+            black_box(b_ptr);
+        });
+    }
+
+    // Parallel variants
+    #[cfg(feature = "parallel")]
+    {
+        let src_perm = src.view().permute(&perm_inv).unwrap();
+        bench_n("copy_into_par", 2, 30, bytes, || {
+            copy_into_par(&mut dst.view_mut(), &src_perm).unwrap();
+            black_box(dst.data().as_ptr());
+        });
+    }
+
+    println!();
+}
+
+/// Scenario 3: memcpy baseline
+///
+/// Contiguous copy (no permutation) for bandwidth reference.
+fn scenario_memcpy_baseline() {
+    println!("=== Scenario 3: memcpy baseline (16M f64 elems) ===");
+
+    let total: usize = 1 << 24; // 16,777,216
+    let bytes = total * std::mem::size_of::<f64>() * 2;
+
+    let src: Vec<f64> = (0..total).map(|i| i as f64).collect();
+    let mut dst = vec![0.0f64; total];
+
+    bench_n("std::ptr::copy_nonoverlapping", 2, 30, bytes, || {
+        unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), total) };
+        black_box(dst.as_ptr());
+    });
+
+    // Also test copy_into with both contiguous (should hit fast path)
+    let dims = vec![2usize; 24];
+    let strides = col_major_strides(&dims);
+    let src_arr = make_random_array(&dims, &strides, 42);
+    let mut dst_arr = StridedArray::<f64>::col_major(&dims);
+    bench_n("copy_into (contiguous fast path)", 2, 30, bytes, || {
+        copy_into(&mut dst_arr.view_mut(), &src_arr.view()).unwrap();
+        black_box(dst_arr.data().as_ptr());
+    });
+
+    println!();
+}
+
+/// Scenario 4: Small tensor permutation
+///
+/// 13 dimensions, all size 2, 8,192 elements.
+/// Tests overhead for small tensors.
+fn scenario_small_tensor() {
+    println!("=== Scenario 4: Small tensor permutation (13 dims, 8K elems) ===");
+
+    let rank = 13;
+    let dims = vec![2usize; rank];
+    let total: usize = 1 << rank; // 8192
+    let bytes = total * std::mem::size_of::<f64>() * 2;
+    let strides = col_major_strides(&dims);
+
+    // Reverse permutation (worst case)
+    let perm_rev: Vec<usize> = (0..rank).rev().collect();
+
+    let src = make_random_array(&dims, &strides, 42);
+    let mut dst = StridedArray::<f64>::col_major(&dims);
+
+    let src_perm = src.view().permute(&perm_rev).unwrap();
+
+    bench_n("strided_perm::copy_into (reverse)", 5, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Cyclic shift
+    let perm_cyc: Vec<usize> = {
+        let mut p: Vec<usize> = (1..rank).collect();
+        p.push(0);
+        p
+    };
+    let src_cyc = src.view().permute(&perm_cyc).unwrap();
+    bench_n("strided_perm::copy_into (cyclic)", 5, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_cyc).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Naive
+    {
+        let a_ptr = src.data().as_ptr();
+        let b_ptr = dst.data_mut().as_mut_ptr();
+        bench_n("naive_odometer (reverse)", 5, 30, bytes, || {
+            unsafe { naive_permute_colmajor(a_ptr, b_ptr, &dims, &perm_rev) };
+            black_box(b_ptr);
+        });
+    }
+
+    // Parallel
+    #[cfg(feature = "parallel")]
+    {
+        bench_n("copy_into_par (reverse)", 5, 30, bytes, || {
+            copy_into_par(&mut dst.view_mut(), &src_perm).unwrap();
+            black_box(dst.data().as_ptr());
+        });
+    }
+
+    println!();
+}
+
+/// Scenario 5: Fewer large dimensions
+///
+/// 3 dimensions, sizes [256, 256, 256] (16M elements).
+/// Transpose: [2, 0, 1]. Traditional blocking shines here.
+fn scenario_large_dims() {
+    println!("=== Scenario 5: Fewer large dimensions ([256, 256, 256], transpose [2,0,1]) ===");
+
+    let dims = vec![256, 256, 256];
+    let total: usize = dims.iter().product(); // 16,777,216
+    let bytes = total * std::mem::size_of::<f64>() * 2;
+    let strides = col_major_strides(&dims);
+    let perm = vec![2, 0, 1];
+
+    let src = make_random_array(&dims, &strides, 42);
+    let mut dst = StridedArray::<f64>::col_major(&dims);
+
+    let src_perm = src.view().permute(&perm).unwrap();
+
+    bench_n("strided_perm::copy_into", 2, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    bench_n("strided_perm::copy_into_col_major", 2, 30, bytes, || {
+        copy_into_col_major(&mut dst.view_mut(), &src_perm).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Naive baseline with precomputed strides
+    {
+        let a_ptr = src.data().as_ptr();
+        let b_ptr = dst.data_mut().as_mut_ptr();
+        bench_n("naive_odometer", 2, 30, bytes, || {
+            unsafe { naive_permute_colmajor(a_ptr, b_ptr, &dims, &perm) };
+            black_box(b_ptr);
+        });
+    }
+
+    // Also test simple transpose [1, 0, 2]
+    let perm2 = vec![1, 0, 2];
+    let src_perm2 = src.view().permute(&perm2).unwrap();
+    bench_n("copy_into (transpose [1,0,2])", 2, 30, bytes, || {
+        copy_into(&mut dst.view_mut(), &src_perm2).unwrap();
+        black_box(dst.data().as_ptr());
+    });
+
+    // Parallel
+    #[cfg(feature = "parallel")]
+    {
+        bench_n("copy_into_par [2,0,1]", 2, 30, bytes, || {
+            copy_into_par(&mut dst.view_mut(), &src_perm).unwrap();
+            black_box(dst.data().as_ptr());
+        });
+        bench_n("copy_into_par [1,0,2]", 2, 30, bytes, || {
+            copy_into_par(&mut dst.view_mut(), &src_perm2).unwrap();
+            black_box(dst.data().as_ptr());
+        });
+    }
+
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// Correctness verification
+// ---------------------------------------------------------------------------
+
+fn verify_scenario(label: &str, dims: &[usize], src_strides: &[isize], perm: &[usize]) {
+    let total: usize = dims.iter().product();
+    let src = make_random_array(dims, src_strides, 99);
+    let mut dst_naive = StridedArray::<f64>::col_major(dims);
+    let mut dst_strided = StridedArray::<f64>::col_major(dims);
+
+    // Build the same permuted view that copy_into will see
+    let src_perm = src.view().permute(perm).unwrap();
+    let perm_src_strides: Vec<isize> = src_perm.strides().to_vec();
+    let dst_cm = col_major_strides(dims);
+
+    unsafe {
+        naive_strided_copy(
+            src.data().as_ptr(),
+            dst_naive.data_mut().as_mut_ptr(),
+            dims,
+            &perm_src_strides,
+            &dst_cm,
+        );
+    }
+
+    copy_into(&mut dst_strided.view_mut(), &src_perm).unwrap();
+
+    for i in 0..total {
+        assert_eq!(
+            dst_naive.data()[i],
+            dst_strided.data()[i],
+            "Mismatch at element {i} for '{label}'"
+        );
+    }
+    println!("  [OK] {label}");
+}
+
+fn run_correctness_checks() {
+    println!("--- Correctness verification ---");
+
+    // Scenario 1: scattered strides
+    let dims24 = vec![2usize; 24];
+    let scattered_strides: Vec<isize> = vec![
+        1, 2, 4, 8, 4194304, 16, 8388608, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+        32768, 65536, 131072, 262144, 524288, 1048576, 2097152,
+    ];
+    let perm_inv: Vec<usize> = vec![
+        0, 1, 2, 3, 22, 4, 23, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    ];
+    verify_scenario(
+        "scattered→colmajor (24d)",
+        &dims24,
+        &scattered_strides,
+        &perm_inv,
+    );
+
+    // Scenario 2: contiguous + permutation
+    let cm_strides = col_major_strides(&dims24);
+    verify_scenario("contig→contig perm (24d)", &dims24, &cm_strides, &perm_inv);
+
+    // Scenario 4: small tensor
+    let dims13 = vec![2usize; 13];
+    let sm_strides = col_major_strides(&dims13);
+    let perm_rev13: Vec<usize> = (0..13).rev().collect();
+    verify_scenario(
+        "small tensor reverse (13d)",
+        &dims13,
+        &sm_strides,
+        &perm_rev13,
+    );
+
+    // Scenario 5: large dims
+    let dims3 = vec![256, 256, 256];
+    let strides3 = col_major_strides(&dims3);
+    verify_scenario("large dims [2,0,1]", &dims3, &strides3, &[2, 0, 1]);
+    verify_scenario("large dims [1,0,2]", &dims3, &strides3, &[1, 0, 2]);
+
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+fn main() {
+    println!("strided-perm permutation benchmarks");
+    println!("====================================");
+    println!(
+        "Element size: {} bytes, 16M elements = {} MB",
+        std::mem::size_of::<f64>(),
+        (1 << 24) * std::mem::size_of::<f64>() / (1024 * 1024)
+    );
+    #[cfg(feature = "parallel")]
+    {
+        let nthreads = rayon::current_num_threads();
+        println!("Parallel feature: enabled ({nthreads} threads)");
+    }
+    #[cfg(not(feature = "parallel"))]
+    println!("Parallel feature: disabled (single-threaded only)");
+    println!("Format: label  median_ms  (p25 / p75)  bandwidth_GB/s");
+    println!();
+
+    run_correctness_checks();
+    scenario_memcpy_baseline();
+    scenario_scattered_to_colmajor();
+    scenario_contig_to_contig_perm();
+    scenario_small_tensor();
+    scenario_large_dims();
+
+    println!("Done.");
+}

--- a/micro_bench/run_hptt_compare.sh
+++ b/micro_bench/run_hptt_compare.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HPTT_DIR="${HPTT_DIR:-../hptt}"
+CXX="${CXX:-/opt/homebrew/bin/g++-15}"
+OUT="${OUT:-target/hptt_compare}"
+
+mkdir -p "$(dirname "$OUT")"
+
+"$CXX" \
+  -O3 \
+  -DNDEBUG \
+  -std=gnu++11 \
+  -fopenmp \
+  -mcpu=native \
+  -I"$HPTT_DIR/include" \
+  micro_bench/hptt_compare.cpp \
+  "$HPTT_DIR/src/hptt.cpp" \
+  "$HPTT_DIR/src/plan.cpp" \
+  "$HPTT_DIR/src/transpose.cpp" \
+  "$HPTT_DIR/src/utils.cpp" \
+  -o "$OUT"
+
+"$OUT"
+

--- a/micro_bench/scale_transpose.rs
+++ b/micro_bench/scale_transpose.rs
@@ -1,0 +1,252 @@
+//! Micro-benchmark for 2D transpose-scale paths.
+//!
+//! This tracks cases where a raw pointer naive loop previously matched or beat
+//! the strided path. Run benchmarks sequentially; do not run 1T and 4T jobs at
+//! the same time.
+
+use num_complex::{Complex32, Complex64};
+use std::fmt::Debug;
+use std::hint::black_box;
+use std::ops::Mul;
+use std::time::Instant;
+use strided_kernel::{copy_transpose_scale_into, map_into};
+use strided_view::{ElementOpApply, StridedArray};
+
+trait BenchScalar:
+    Copy
+    + Clone
+    + Default
+    + Debug
+    + PartialEq
+    + ElementOpApply
+    + Mul<Output = Self>
+    + num_traits::Zero
+    + num_traits::One
+    + Send
+    + Sync
+    + 'static
+{
+    const NAME: &'static str;
+
+    fn from_index(i: usize) -> Self;
+    fn scale_three() -> Self;
+}
+
+impl BenchScalar for f32 {
+    const NAME: &'static str = "f32";
+
+    #[inline]
+    fn from_index(i: usize) -> Self {
+        i as f32 * 0.25 + 1.0
+    }
+
+    #[inline]
+    fn scale_three() -> Self {
+        3.0
+    }
+}
+
+impl BenchScalar for f64 {
+    const NAME: &'static str = "f64";
+
+    #[inline]
+    fn from_index(i: usize) -> Self {
+        i as f64 * 0.25 + 1.0
+    }
+
+    #[inline]
+    fn scale_three() -> Self {
+        3.0
+    }
+}
+
+impl BenchScalar for Complex32 {
+    const NAME: &'static str = "c32";
+
+    #[inline]
+    fn from_index(i: usize) -> Self {
+        Complex32::new(i as f32 * 0.25 + 1.0, i as f32 * -0.125)
+    }
+
+    #[inline]
+    fn scale_three() -> Self {
+        Complex32::new(3.0, -0.5)
+    }
+}
+
+impl BenchScalar for Complex64 {
+    const NAME: &'static str = "c64";
+
+    #[inline]
+    fn from_index(i: usize) -> Self {
+        Complex64::new(i as f64 * 0.25 + 1.0, i as f64 * -0.125)
+    }
+
+    #[inline]
+    fn scale_three() -> Self {
+        Complex64::new(3.0, -0.5)
+    }
+}
+
+impl BenchScalar for u64 {
+    const NAME: &'static str = "u64";
+
+    #[inline]
+    fn from_index(i: usize) -> Self {
+        i as u64 + 1
+    }
+
+    #[inline]
+    fn scale_three() -> Self {
+        3
+    }
+}
+
+fn bench<F: FnMut()>(mut f: F, warmup: usize, nruns: usize) -> (f64, f64) {
+    for _ in 0..warmup {
+        f();
+    }
+    let mut times = Vec::with_capacity(nruns);
+    for _ in 0..nruns {
+        let t = Instant::now();
+        f();
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let med = times[times.len() / 2];
+    let iqr = times[3 * times.len() / 4] - times[times.len() / 4];
+    (med, iqr)
+}
+
+#[inline(never)]
+fn naive_transpose_scale<T: BenchScalar>(dst: *mut T, src: *const T, n: usize, scale: T) {
+    unsafe {
+        if scale == T::zero() {
+            for j in 0..n {
+                let col = j * n;
+                for i in 0..n {
+                    *dst.add(col + i) = T::zero();
+                }
+            }
+            return;
+        }
+
+        for j in 0..n {
+            let col = j * n;
+            for i in 0..n {
+                *dst.add(col + i) = scale * *src.add(i * n + j);
+            }
+        }
+    }
+}
+
+fn make_col_major<T: BenchScalar>(n: usize) -> StridedArray<T> {
+    StridedArray::<T>::from_fn_col_major(&[n, n], |idx| T::from_index(idx[0] + idx[1] * n))
+}
+
+fn run_case<T: BenchScalar>(n: usize, scale: T, scale_name: &str, warmup: usize, nruns: usize) {
+    let a = make_col_major::<T>(n);
+    let a_view = a.view();
+    let a_t = a_view.transpose_2d().unwrap();
+    let a_perm = a_view.permute(&[1, 0]).unwrap();
+    let mut b = StridedArray::<T>::col_major(&[n, n]);
+    let src_ptr = a.data().as_ptr();
+    let dst_ptr = b.data_mut().as_mut_ptr();
+
+    let (naive_med, naive_iqr) = bench(
+        || {
+            naive_transpose_scale(dst_ptr, src_ptr, n, scale);
+            black_box(dst_ptr);
+        },
+        warmup,
+        nruns,
+    );
+
+    let (strided_med, strided_iqr) = bench(
+        || {
+            copy_transpose_scale_into(&mut b.view_mut(), &a_view, scale).unwrap();
+            black_box(dst_ptr);
+        },
+        warmup,
+        nruns,
+    );
+
+    let (map_med, map_iqr) = bench(
+        || {
+            map_into(&mut b.view_mut(), &a_t, |x| scale * x).unwrap();
+            black_box(dst_ptr);
+        },
+        warmup,
+        nruns,
+    );
+
+    println!(
+        "{:<4} n={:<4} scale={:<5} {:>11.3} ({:>6.3}) {:>11.3} ({:>6.3}) {:>11.3} ({:>6.3})",
+        T::NAME,
+        n,
+        scale_name,
+        naive_med,
+        naive_iqr,
+        strided_med,
+        strided_iqr,
+        map_med,
+        map_iqr
+    );
+
+    if scale == T::one() {
+        let (copy_med, copy_iqr) = bench(
+            || {
+                strided_perm::copy_into(&mut b.view_mut(), &a_perm).unwrap();
+                black_box(dst_ptr);
+            },
+            warmup,
+            nruns,
+        );
+        println!(
+            "{:<4} n={:<4} scale={:<5} copy_into  {:>11.3} ({:>6.3})",
+            T::NAME,
+            n,
+            scale_name,
+            copy_med,
+            copy_iqr
+        );
+    }
+}
+
+fn run_dtype<T: BenchScalar>(sizes: &[usize], warmup: usize, nruns: usize) {
+    for &n in sizes {
+        run_case::<T>(n, T::zero(), "0", warmup, nruns);
+        run_case::<T>(n, T::one(), "1", warmup, nruns);
+        run_case::<T>(n, T::scale_three(), "3", warmup, nruns);
+    }
+}
+
+fn main() {
+    let warmup = std::env::var("WARMUP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+    let nruns = std::env::var("NRUNS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(11);
+    let sizes: Vec<usize> = std::env::var("SIZES")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .map(|v| v.trim().parse().expect("invalid SIZES entry"))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![1000, 1024, 2048]);
+
+    println!("2D transpose-scale micro-benchmark");
+    println!("warmup={warmup} nruns={nruns} sizes={sizes:?}");
+    println!("columns: dtype n scale naive_ms(iqr) strided_ms(iqr) map_ms(iqr)");
+    println!("{}", "-".repeat(92));
+
+    run_dtype::<f32>(&sizes, warmup, nruns);
+    run_dtype::<f64>(&sizes, warmup, nruns);
+    run_dtype::<Complex32>(&sizes, warmup, nruns);
+    run_dtype::<Complex64>(&sizes, warmup, nruns);
+    run_dtype::<u64>(&sizes, warmup, nruns);
+}


### PR DESCRIPTION
## Summary
- migrate strided-perm permutation benchmark coverage into the benchmark suite
- add scale-transpose benchmark coverage for f32/f64/c32/c64/u64 across scale 0/1/3
- add an HPTT comparison runner using Homebrew GCC/OpenMP on macOS, limited to directly matching verified transpose cases
- replace old AMD benchmark results with M5 MacBook Pro results and record strided-rs commit 91a0aca

## Related
- strided-rs implementation PR: https://github.com/tensor4all/strided-rs/pull/133

## Verification
- cargo check --bin scale_transpose --bin permute
- cargo check --features parallel --bin scale_transpose --bin permute
- bash -n micro_bench/run_hptt_compare.sh && test -x micro_bench/run_hptt_compare.sh && git diff --check
- HPTT smoke run with CXX=/opt/homebrew/bin/g++-15
- permutation benchmark rerun with RAYON_NUM_THREADS=1 and 4